### PR TITLE
Fix "method `cleanup_application' not defined in Class" error when running Migrates

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,6 @@
 if Rails.env.development? || (config.respond_to?(:soft_reload) && config.soft_reload)
-  require 'rails_development_boost'
-  RailsDevelopmentBoost.apply!
+  if ENV['_'].grep(/rake$/).empty?
+    require 'rails_development_boost'
+    RailsDevelopmentBoost.apply!
+  end
 end


### PR DESCRIPTION
Hi...

In our proyect, we are having always the error: "method `cleanup_application' not defined in Class" when trying to run the migrations in development environment and this plugin is enabled.

I've put an extra validation in the init.rb and is now fixed, although I don't know if there's a cleaner way to detect if it's a rake task, because right now it uses the ENV[_] variable to detect the executable name lol

Thanks
GF
