### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -47,7 +47,7 @@ Usage through `Gemfile`:
 
 ```ruby
 group :development do
-  gem 'rails-dev-boost', :git => 'git://github.com/thedarkone/rails-dev-boost.git', :require => 'rails_development_boost'
+  gem 'rails-dev-boost', :git => 'git://github.com/thedarkone/rails-dev-boost.git'
 end
 ```
 


### PR DESCRIPTION
looks like rails-dev-boost is already requiring rails_development_boost so no need for an explicit require
