### PR TITLE
Use module_cache method instead of @module_cache

### DIFF
--- a/lib/rails_development_boost/dependencies_patch.rb
+++ b/lib/rails_development_boost/dependencies_patch.rb
@@ -398,7 +398,7 @@ module RailsDevelopmentBoost
     
     def clear_tracks_of_removed_const(const_name, object = nil)
       autoloaded_constants.delete(const_name)
-      @module_cache.remove_const(const_name, object)
+      module_cache.remove_const(const_name, object)
       LoadedFile.const_unloaded(const_name)
     end
     


### PR DESCRIPTION
This fixes a crash that I get on our app (`@module_cache` is nil). I can't really tell you why, but I wanted to share our "hotfix" in case it's really a bug.
