### PR TITLE
Fix variable name in dependencies_patch.rb

### DIFF
--- a/lib/rails_development_boost/dependencies_patch.rb
+++ b/lib/rails_development_boost/dependencies_patch.rb
@@ -476,7 +476,7 @@ module RailsDevelopmentBoost
     
     def clear_tracks_of_removed_const(const_name, object = nil)
       autoloaded_constants.delete(const_name)
-      module_cache.remove_const(const_name, object)
+      @module_cache.remove_const(const_name, object)
       LoadedFile.const_unloaded(const_name)
     end
     


### PR DESCRIPTION
I found a small bug with a Rails 3.2 application, I think one variable was forgotten when renaming ;)
