### PR TITLE
Catch InvalidDirectoryErrors when watching directories.

### DIFF
--- a/lib/rails_development_boost/async/reactor.rb
+++ b/lib/rails_development_boost/async/reactor.rb
@@ -176,8 +176,11 @@ module RailsDevelopmentBoost
         private
         def watch_internal(directories)
           directories.each do |directory|
-            @watcher.watch_recursively(directory) do |change|
-              yield [File.dirname(change.path)]
+            begin
+              @watcher.watch_recursively(directory) do |change|
+                yield [File.dirname(change.path)]
+              end
+            rescue WDM::InvalidDirectoryError
             end
           end
         end


### PR DESCRIPTION
After the first request, subsequent requests might involve monitoring directories which do not exist. Do not disrupt the entire stack when this happens.

I'm running this on Windows, with Rails 4.1.

```
=> Booting WEBrick
=> Rails 4.1.8 application starting in development on http://127.0.0.1:3000
=> Run `rails server -h` for more startup options
=> Ctrl-C to shutdown server
[2014-12-02 15:25:57] INFO  WEBrick 1.3.1
[2014-12-02 15:25:57] INFO  ruby 2.1.5 (2014-11-27) [x64-mswin64_120]
[2014-12-02 15:25:57] INFO  WEBrick::HTTPServer#start: pid=1112 port=3000


Started GET "/" for 127.0.0.1 at 2014-12-02 15:26:14 +0800
Processing by Rails::WelcomeController#index as HTML
  Rendered .bundle/ruby/2.1.0/gems/railties-4.1.8/lib/rails/templates/rails/welcome/index.html.erb (13.4ms)
Completed 200 OK in 88ms (Views: 65.0ms | ActiveRecord: 0.0ms)


Started GET "/" for 127.0.0.1 at 2014-12-02 15:26:18 +0800

WDM::InvalidDirectoryError (No such directory: 'D:/Development/Projects/Coursemology/test/mailers/previews'!):
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async/reactor.rb:179:in `watch_recursively'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async/reactor.rb:179:in `block in watch_internal'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async/reactor.rb:178:in `each'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async/reactor.rb:178:in `watch_internal'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async/reactor.rb:49:in `watch'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async.rb:88:in `start!'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async.rb:33:in `heartbeat_check!'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/dependencies_patch.rb:353:in `unload_modified_files_internal!'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/dependencies_patch.rb:213:in `block in unload_modified_files!'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/dependencies_patch.rb:381:in `block in async_synchronize'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async.rb:39:in `block in synchronize'
  C:/Ruby215/lib/ruby/2.1.0/monitor.rb:211:in `mon_synchronize'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/async.rb:39:in `synchronize'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/dependencies_patch.rb:381:in `async_synchronize'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/dependencies_patch.rb:212:in `unload_modified_files!'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/reloader.rb:43:in `execute'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/reloader.rb:47:in `execute_if_updated'
  .bundle/ruby/2.1.0/gems/rails-dev-boost-0.3.0/lib/rails_development_boost/reloader.rb:37:in `block in hook_in!'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:438:in `instance_exec'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:438:in `block in make_lambda'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:184:in `call'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:184:in `block in simple'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:185:in `call'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:185:in `block in simple'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:86:in `call'
  .bundle/ruby/2.1.0/gems/activesupport-4.1.8/lib/active_support/callbacks.rb:86:in `run_callbacks'
  .bundle/ruby/2.1.0/gems/actionpack-4.1.8/lib/action_dispatch/middleware/reloader.rb:83:in `prepare!'
  .bundle/ruby/2.1.0/gems/actionpack-4.1.8/lib/action_dispatch/middleware/reloader.rb:55:in `prepare!'
  .bundle/ruby/2.1.0/gems/rails-dev-tweaks-1.2.0/lib/rails_dev_tweaks/granular_autoload/middleware.rb
<<snip>>
```

I don't know why test/mailers/previews is being watched because it doesn't exist. But I imagine this can happen in other scenarios, too.
