### PR TITLE
Only deduce that we are in a console if IRB is loaded and there is an active session

### DIFF
--- a/lib/rails_development_boost/async.rb
+++ b/lib/rails_development_boost/async.rb
@@ -74,7 +74,7 @@ module RailsDevelopmentBoost
     
     private
     def in_console?
-      defined?(IRB) || defined?(Pry)
+      (defined?(IRB) && defined?(IRB::CurrentContext)) || defined?(Pry)
     end
     
     def async_warning(msg)


### PR DESCRIPTION
Some gems include parts of IRB but do not enable the console functionality (e.g. ruby-debug-ide).