### PR TITLE
Cache Sprockets path lookup when the path is determined to be from a gem.

### DIFF
--- a/lib/rails_development_boost.rb
+++ b/lib/rails_development_boost.rb
@@ -13,7 +13,8 @@ module RailsDevelopmentBoost
         else
           ActionDispatch::Callbacks.before(:prepend => true)    { ActiveSupport::Dependencies.unload_modified_files! }
         end
-        
+
+        ::Sprockets::Environment.prepend(Sprockets::PathCacheEnvironment)
         DependenciesPatch.enable_async_mode_by_default!
       end
     end
@@ -53,7 +54,9 @@ module RailsDevelopmentBoost
   autoload :ReferenceCleanupPatch,   'rails_development_boost/reference_cleanup_patch'
   autoload :Reloader,                'rails_development_boost/reloader'
   autoload :RequiredDependency,      'rails_development_boost/required_dependency'
+  autoload :Sprockets,               'rails_development_boost/sprockets'
   autoload :RoutesLoadedFile,        'rails_development_boost/routes_loaded_file'
+
   autoload :ViewHelpersPatch,        'rails_development_boost/view_helpers_patch'
   
   def self.debug!

--- a/lib/rails_development_boost/sprockets.rb
+++ b/lib/rails_development_boost/sprockets.rb
@@ -1,0 +1,6 @@
+module RailsDevelopmentBoost
+  module Sprockets
+    autoload :PathCache,            'rails_development_boost/sprockets/path_cache'
+    autoload :PathCacheEnvironment, 'rails_development_boost/sprockets/path_cache_environment'
+  end
+end

--- a/lib/rails_development_boost/sprockets/path_cache.rb
+++ b/lib/rails_development_boost/sprockets/path_cache.rb
@@ -1,0 +1,27 @@
+ module RailsDevelopmentBoost
+   module Sprockets
+     module PathCache
+       # @!attribute[r] resolve_path_cache
+       #   The path resolution cache. This is keyed by path, and the value is either a string
+       #   containing the resolved path, or false to indicate that it should not be cached.
+       mattr_reader :resolve_path_cache
+       @@resolve_path_cache = {}
+
+       def resolve(path, options = {})
+         cached_path = PathCache.resolve_path_cache[path]
+         return cached_path if cached_path
+
+         result = super
+         return result if cached_path == false || result.first.nil?
+
+         raw_path = parse_asset_uri(result.first).first
+         if Bundler.rubygems.all_specs.any? { |s| raw_path.start_with?(s.full_gem_path) }
+           PathCache.resolve_path_cache[path] = result
+         else
+           PathCache.resolve_path_cache[path] = false
+         end
+         result
+       end
+     end
+   end
+ end

--- a/lib/rails_development_boost/sprockets/path_cache_environment.rb
+++ b/lib/rails_development_boost/sprockets/path_cache_environment.rb
@@ -1,0 +1,11 @@
+module RailsDevelopmentBoost
+  module Sprockets
+    module PathCacheEnvironment
+      def cached
+        result = super
+        result.singleton_class.prepend(RailsDevelopmentBoost::Sprockets::PathCache)
+        result
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since changing gems requires a reboot of the Rails server anyway, caching this should be safe. This gives a 10% page load improvement.

This is written with Sprockets 3.2

Hopefully Sprockets 4 with source maps would make this obsolete, but in the meantime...
